### PR TITLE
rewrite host header in base input string for httpsig

### DIFF
--- a/bartholomew/spin.toml
+++ b/bartholomew/spin.toml
@@ -3,7 +3,7 @@ authors = ["patterns <addq1eax@gmail.com>"]
 description = "Pink Elephants on Parade"
 name = "cloud_start"
 trigger = { type = "http", base = "/" }
-version = "0.6.4"
+version = "0.6.5"
 
 [variables]
 self_actor = { default = "echo" }
@@ -13,6 +13,8 @@ redis_server = { required = true }
 redis_login = { required = true, secret = true }
 verifier_proxy = { required = true }
 verifier_bearer = { required = true, secret = true }
+httpsig_origin = { default = "" }
+httpsig_gateway = { default = "" }
 
 [[component]]
 id = "bartholomew"
@@ -42,6 +44,8 @@ route = "/inbox"
 redis_address = "redis://{{ redis_login }}@{{ redis_server }}"
 verifier_proxy_uri = "https://{{ verifier_proxy }}/api/verifiers"
 verifier_proxy_bearer = "{{ verifier_bearer }}"
+httpsig_host_origin = "{{ httpsig_origin }}"
+httpsig_host_gateway = "{{ httpsig_gateway }}"
 
 [[component]]
 id = "outbox"
@@ -53,6 +57,8 @@ route = "/outbox"
 redis_address = "redis://{{ redis_login }}@{{ redis_server }}"
 verifier_proxy_uri = "https://{{ verifier_proxy }}/api/verifiers"
 verifier_proxy_bearer = "{{ verifier_bearer }}"
+httpsig_host_origin = "{{ httpsig_origin }}"
+httpsig_host_gateway = "{{ httpsig_gateway }}"
 
 [[component]]
 id = "webfinger"

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "pinkelephants",
-    .version = "0.1.6",
+    .version = "0.1.7",
 
 
 

--- a/src/proxyverify.zig
+++ b/src/proxyverify.zig
@@ -12,6 +12,11 @@ pub fn verifySignature(ally: Allocator, rcv: anytype) bool {
 
     vrf.attachFetch(produceVerifierByProxy);
 
+    // conf setting for the host header rewrite
+    const httpsig_origin = spin.config.httpsigOrigin() orelse "localhost";
+    const httpsig_gateway = spin.config.httpsigGateway() orelse "load-balancer";
+    vrf.rewriteRule(httpsig_origin, httpsig_gateway);
+
     var buffer: [512]u8 = undefined;
     var chan = std.io.fixedBufferStream(&buffer);
     vrf.fmtBase(rcv, chan.writer()) catch {

--- a/src/spin/config.zig
+++ b/src/spin/config.zig
@@ -15,6 +15,12 @@ pub fn verifierProxyUri() ?[]u8 {
 pub fn verifierProxyBearer() ?[]u8 {
     return get("verifier_proxy_bearer");
 }
+pub fn httpsigOrigin() ?[]u8 {
+    return get("httpsig_host_origin");
+}
+pub fn httpsigGateway() ?[]u8 {
+    return get("httpsig_host_gateway");
+}
 
 /////////////////////////////////////////////////////////////
 // WASI C/interop


### PR DESCRIPTION
in the configuration with a CF gateway that forwards to our low-power origin, the host header needs to be rewritten to the hostname of the CF gateway. Otherwise the HTTP signature hash will not match.